### PR TITLE
Fix help/usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pip install -r requirements.txt
 
 ```bash
 ./src/auto_submit_tips.py -h
-usage: Kicktipp auto tipping [-h] [-2 | -r]
+usage: auto_submit_tips.py [-h] [-2 | -r]
 
 Perform automatic kicktipp tipping for the bots
 

--- a/src/auto_submit_tips.py
+++ b/src/auto_submit_tips.py
@@ -32,7 +32,6 @@ def parse_args():
     return (list): Return parsed arguments
     """
     parser = argparse.ArgumentParser(
-        prog='Kicktipp auto tipping',
         description='Perform automatic kicktipp tipping for the bots')
     group = parser.add_mutually_exclusive_group()
     group.add_argument('-2',


### PR DESCRIPTION
Remove `progname`, so the script name is being shown when showing the usage